### PR TITLE
update safe_yaml to run specs with Ruby 2.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,7 +109,7 @@ GEM
     rspec-mocks (3.0.4)
       rspec-support (~> 3.0.0)
     rspec-support (3.0.4)
-    safe_yaml (1.0.3)
+    safe_yaml (1.0.4)
     sinatra (1.4.5)
       rack (~> 1.4)
       rack-protection (~> 1.4)
@@ -164,3 +164,6 @@ DEPENDENCIES
   unicorn
   vcr
   webmock
+
+BUNDLED WITH
+   1.10.5


### PR DESCRIPTION
Forked and tried to run the specs, failed with this issue: https://github.com/dtao/safe_yaml/issues/67

Commit updates safe_yaml gem from version 1.0.3 to 1.0.4.  Specs run with Ruby 2.2 now.